### PR TITLE
Exclude x13hash from gitignore

### DIFF
--- a/src/obj/.gitignore
+++ b/src/obj/.gitignore
@@ -1,2 +1,3 @@
 *
 !.gitignore
+!x13hash/*


### PR DESCRIPTION
x13hash is required to build the wallet, .gitignore must exclude that directory