### PR TITLE
added new build script to easily support static builds

### DIFF
--- a/new-build.sh
+++ b/new-build.sh
@@ -11,31 +11,22 @@ cleandeps(){
     rm -rf libsodium*
 }
 
-build_cli(){
-
-    cd src
-    mkdir ../binarys
-    if [[ "$@" == "--static" ]]
-    then
-        make -j$NPROC -f makefile.unix STATIC=1
-    else
+build_cli_dyn(){
         make -j$NPROC -f makefile.unix
-    fi
-
-    mv obsidiand ../binarys/
-    cd ..
 }
 
-build_gui(){
-    if [[ "$@" == "--static" ]]
-    then
-        qmake "RELEASE=1"
-    else
-        qmake
-    fi
+build_cli_static(){
+STATIC=1 make -j$NPROC -f makefile.unix
+}
 
+build_gui_static(){
+    qmake "RELEASE=1"
     make -j$NPROC
-    mv Obsidian-Qt binarys/
+}
+
+build_gui_dyn(){
+    qmake
+    make -j$NPROC
 }
 
 init(){
@@ -93,5 +84,20 @@ install_deps(){
 install_deps
 cleandeps
 init
-build_cli
-build_gui
+mkdir binarys
+if [[ "$1" == "--static" ]]
+then
+    cd src
+    build_cli_static
+    mv obsidiand ../binarys
+    cd ..
+    build_gui_static
+    mv Obsidian-Qt binarys/
+else
+    cd src
+    build_cli_dyn
+    mv obsidiand ../binarys
+    cd ..
+    build_gui_dyn
+    mv Obsidian-Oq binarys/
+fi

--- a/new-build.sh
+++ b/new-build.sh
@@ -1,0 +1,97 @@
+#!/bin/bash
+
+
+#################################################################
+# Define functions necessary for building Obsidian              #
+#################################################################
+NPROC=$(nproc)
+
+cleandeps(){
+    rm -rf LATEST.tar.gz
+    rm -rf libsodium*
+}
+
+build_cli(){
+
+    cd src
+    mkdir ../binarys
+    if [[ "$@" == "--static" ]]
+    then
+        make -j$NPROC -f makefile.unix STATIC=1
+    else
+        make -j$NPROC -f makefile.unix
+    fi
+
+    mv obsidiand ../binarys/
+    cd ..
+}
+
+build_gui(){
+    if [[ "$@" == "--static" ]]
+    then
+        qmake "RELEASE=1"
+    else
+        qmake
+    fi
+
+    make -j$NPROC
+    mv Obsidian-Qt binarys/
+}
+
+init(){
+    mkdir -p ~/.obsidian && touch $_/obsidian.conf
+    config=~/.obsidian/obsidian.conf
+    echo "(Required) RPC User: "
+    read user
+    echo "rpcuser=$user" >> $config
+    echo "(Required) RPC Password: "
+    unset password;
+    while IFS=$'\n' read -r -s -n1 pass; do
+        if [[ -z $pass ]]; then
+            echo
+            break
+        else
+            echo -n '*'
+            password+=$pass
+        fi
+    done
+    echo "rpcpassword=$password" >> $config
+    echo "(Optional) Email Address For Wallet Alerts: "
+    read email
+    echo "alertnotify=echo %s | mail -s 'Obsidian Alert' $email" >> $config
+}
+
+install_deps(){
+    #################################################################
+    # Update Ubuntu and install prerequisites for running Obsidian  #
+    #################################################################
+    sudo apt-get update
+    #################################################################
+    # Build Obsidian from source                                    #
+    #################################################################
+    NPROC=$(nproc)
+    echo "nproc: $NPROC"
+    #################################################################
+    # Install all necessary packages for building Obsidian          #
+    #################################################################
+    sudo apt-get install -y qt4-qmake libqt4-dev libminiupnpc-dev libdb++-dev libdb-dev libcrypto++-dev libqrencode-dev libboost-all-dev build-essential libboost-system-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libboost-filesystem-dev libboost-program-options-dev libboost-thread-dev libssl-dev libdb++-dev libssl-dev ufw git
+    sudo add-apt-repository -y ppa:bitcoin/bitcoin
+    sudo apt-get update
+    sudo apt-get install -y libdb4.8-dev libdb4.8++-dev
+    wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz
+    tar -xvzf LATEST.tar.gz
+    cd libsodium*
+    ./configure
+    make
+    make check
+    sudo make install
+    sudo ldconfig
+    sudo apt-get install -y libsodium
+    cd ..
+}
+
+install_deps
+cleandeps
+init
+build_cli
+build_gui

--- a/src/makefile.unix
+++ b/src/makefile.unix
@@ -31,6 +31,7 @@ LIBS += \
    -l boost_thread$(BOOST_LIB_SUFFIX) \
    -l db_cxx$(BDB_LIB_SUFFIX) \
    -l ssl \
+   -l sodium \
    -l crypto
 
 ifndef USE_UPNP
@@ -97,7 +98,7 @@ xCXXFLAGS=-O2 $(EXT_OPTIONS) -pthread -Wall -Wextra -Wno-ignored-qualifiers -Wfo
 
 # LDFLAGS can be specified on the make command line, so we use xLDFLAGS that only
 # adds some defaults in front. Unfortunately, LDFLAGS=... $(LDFLAGS) does not work.
-xLDFLAGS=$(LDHARDENING) $(LDFLAGS) -lsodium
+xLDFLAGS=$(LDHARDENING) $(LDFLAGS)
 
 OBJS= \
     obj/alert.o \


### PR DESCRIPTION
Added a new build file, which easily supports building staticly linked binarys.
The new script is called `new_build.sh`. 
It builds the obsidiand and Obsidian-Qt targets, and moves them into a `binary/` dir.
Per default the script builds dynamicly linked binarys.
When you pass the `--static` parameter to the script it builds staticly linked binarys.